### PR TITLE
issue-271 : removed hardcoded UUIDs

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -7,7 +7,7 @@ var oas3Tools = require('openbackhaul-oas3-tools');
 var appCommons = require('onf-core-model-ap/applicationPattern/commons/AppCommons');
 var serverPort = 3005;
 
-const prepareElasticsearch = require('./service/individualServices/ElasticsearchPreparation');
+const ElasticsearchPreparation = require('./service/individualServices/ElasticsearchPreparation');
 
 // uncomment if you do not want to validate security e.g. operation-key, basic auth, etc
 // appCommons.openApiValidatorOptions.validateSecurity = false;
@@ -33,6 +33,6 @@ http.createServer(app).listen(serverPort, function () {
 //setting the path to the database 
 global.databasePath = './database/load.json'
 
-prepareElasticsearch().then().catch(err => {
+ElasticsearchPreparation.prepareElasticsearch().then().catch(err => {
     console.error(`Error preparing Elasticsearch : ${err}`);
 });

--- a/server/service/individualServices/ForwardingService.js
+++ b/server/service/individualServices/ForwardingService.js
@@ -3,13 +3,14 @@ const {
     getIndexAliasAsync
 } = require('onf-core-model-ap/applicationPattern/services/ElasticsearchService');
 const onfAttributes = require('onf-core-model-ap/applicationPattern/onfModel/constants/OnfAttributes');
-const getCorrectEsUuid = require('./ElasticsearchPreparation');
+const ElasticsearchPreparation = require('./ElasticsearchPreparation');
 
 exports.updateForwardingConstructList = function (forwardingConstructListToBeUpdated) {
     return new Promise(async function (resolve, reject) {
         try {
-            let client = await elasticsearchService.getClient(false, await getCorrectEsUuid(false));
-            let indexAlias = await getIndexAliasAsync(await getCorrectEsUuid(false));
+            let esUuid = await ElasticsearchPreparation.getCorrectEsUuid(false);
+            let client = await elasticsearchService.getClient(false, esUuid);
+            let indexAlias = await getIndexAliasAsync(false, esUuid);
             let response;
             if (Object.keys(forwardingConstructListToBeUpdated).length >= 2) {
 
@@ -37,8 +38,9 @@ async function getForwardingDomainFromControlConstruct(controlConstructUuid) {
     return new Promise(async function (resolve, reject) {
         let forwardingDomainOfControlConstruct = {}
         try {
-            let client = await elasticsearchService.getClient(false, await getCorrectEsUuid(false));
-            let indexAlias = await getIndexAliasAsync(await getCorrectEsUuid(false));
+            let esUuid = await ElasticsearchPreparation.getCorrectEsUuid(false);
+            let client = await elasticsearchService.getClient(false, esUuid);
+            let indexAlias = await getIndexAliasAsync(esUuid);
             let res = await client.search({
                 index: indexAlias,
                 filter_path: "hits.hits._id,hits.hits._source.forwarding-domain",

--- a/server/service/individualServices/ForwardingService.js
+++ b/server/service/individualServices/ForwardingService.js
@@ -3,14 +3,13 @@ const {
     getIndexAliasAsync
 } = require('onf-core-model-ap/applicationPattern/services/ElasticsearchService');
 const onfAttributes = require('onf-core-model-ap/applicationPattern/onfModel/constants/OnfAttributes');
-
-const ELASTICSEARCH_CLIENT_CC_UUID = "alt-2-0-1-es-c-es-1-0-0-000";
+const getCorrectEsUuid = require('./ElasticsearchPreparation');
 
 exports.updateForwardingConstructList = function (forwardingConstructListToBeUpdated) {
     return new Promise(async function (resolve, reject) {
         try {
-            let client = await elasticsearchService.getClient(false, ELASTICSEARCH_CLIENT_CC_UUID);
-            let indexAlias = await getIndexAliasAsync(ELASTICSEARCH_CLIENT_CC_UUID);
+            let client = await elasticsearchService.getClient(false, await getCorrectEsUuid(false));
+            let indexAlias = await getIndexAliasAsync(await getCorrectEsUuid(false));
             let response;
             if (Object.keys(forwardingConstructListToBeUpdated).length >= 2) {
 
@@ -38,8 +37,8 @@ async function getForwardingDomainFromControlConstruct(controlConstructUuid) {
     return new Promise(async function (resolve, reject) {
         let forwardingDomainOfControlConstruct = {}
         try {
-            let client = await elasticsearchService.getClient(false, ELASTICSEARCH_CLIENT_CC_UUID);
-            let indexAlias = await getIndexAliasAsync(ELASTICSEARCH_CLIENT_CC_UUID);
+            let client = await elasticsearchService.getClient(false, await getCorrectEsUuid(false));
+            let indexAlias = await getIndexAliasAsync(await getCorrectEsUuid(false));
             let res = await client.search({
                 index: indexAlias,
                 filter_path: "hits.hits._id,hits.hits._source.forwarding-domain",

--- a/server/service/individualServices/PrepareForwardingAutomation.js
+++ b/server/service/individualServices/PrepareForwardingAutomation.js
@@ -29,12 +29,12 @@ exports.regardApplication = function (logicalTerminationPointconfigurationStatus
             topologyChangeInformationRequestBody.topologyApplicationReleaseNumber = await httpServerInterface.getReleaseNumberAsync();
             topologyChangeInformationRequestBody.topologyApplicationAddress = await tcpServerInterface.getLocalAddress();
             topologyChangeInformationRequestBody.topologyApplicationPort = await tcpServerInterface.getLocalPort();
-            topologyChangeInformationRequestBody.topologyOperationApplicationUpdate = await operationServerInterface.getOperationNameAsync("alt-2-0-1-op-s-is-004");
-            topologyChangeInformationRequestBody.topologyOperationLtpUpdate = await operationServerInterface.getOperationNameAsync("alt-2-0-1-op-s-is-005");
-            topologyChangeInformationRequestBody.topologyOperationLtpDeletion = await operationServerInterface.getOperationNameAsync("alt-2-0-1-op-s-is-006");
-            topologyChangeInformationRequestBody.topologyOperationFcUpdate = await operationServerInterface.getOperationNameAsync("alt-2-0-1-op-s-is-013");
-            topologyChangeInformationRequestBody.topologyOperationFcPortUpdate = await operationServerInterface.getOperationNameAsync("alt-2-0-1-op-s-is-014");
-            topologyChangeInformationRequestBody.topologyOperationFcPortDeletion = await operationServerInterface.getOperationNameAsync("alt-2-0-1-op-s-is-015");
+            topologyChangeInformationRequestBody.topologyOperationApplicationUpdate = "/v1/update-all-ltps-and-fcs";
+            topologyChangeInformationRequestBody.topologyOperationLtpUpdate = "/v1/update-ltp";
+            topologyChangeInformationRequestBody.topologyOperationLtpDeletion = "/v1/delete-ltp-and-dependents";
+            topologyChangeInformationRequestBody.topologyOperationFcUpdate = "/v1/update-fc";
+            topologyChangeInformationRequestBody.topologyOperationFcPortUpdate = "/v1/update-fc-port";
+            topologyChangeInformationRequestBody.topologyOperationFcPortDeletion = "/v1/delete-fc-port";
             
 
             topologyChangeInformationRequestBody = onfFormatter.modifyJsonObjectKeysToKebabCase(topologyChangeInformationRequestBody);

--- a/server/service/individualServices/SoftwareUpgrade.js
+++ b/server/service/individualServices/SoftwareUpgrade.js
@@ -208,7 +208,7 @@ async function PromptForBequeathingDataCausesRObeingRequestedToNotifyApprovalsOf
 
                 let applicationName = await httpServerInterface.getApplicationNameAsync();
                 let releaseNumber = await httpClientInterface.getReleaseNumberAsync(newReleaseHttpClientUuid);
-                let regardApplicationOperation = await OperationServerInterface.getOperationNameAsync("alt-2-0-1-op-s-is-001");
+                let regardApplicationOperation = "/v1/regard-application";
                 let applicationAddress = await tcpClientInterface.getRemoteAddressAsync(newReleaseTcpClientUuid);
                 let applicationPort = await tcpClientInterface.getRemotePortAsync(newReleaseTcpClientUuid);
                 let applicationProtocol = await tcpClientInterface.getRemoteProtocolAsync(newReleaseTcpClientUuid); 
@@ -273,7 +273,7 @@ async function PromptForBequeathingDataCausesRObeingRequestedToNotifyWithdrawnAp
 
                 let applicationName = await httpServerInterface.getApplicationNameAsync();
                 let releaseNumber = await httpClientInterface.getReleaseNumberAsync(newReleaseHttpClientUuid);
-                let disregardApplicationOperation = await OperationServerInterface.getOperationNameAsync("alt-2-0-1-op-s-is-002");
+                let disregardApplicationOperation = "/v1/disregard-application";
                 let applicationAddress = await tcpClientInterface.getRemoteAddressAsync(newReleaseTcpClientUuid);
                 let applicationPort = await tcpClientInterface.getRemotePortAsync(newReleaseTcpClientUuid);
                 let applicationProtocol = await tcpClientInterface.getRemoteProtocolAsync(newReleaseTcpClientUuid); 


### PR DESCRIPTION
- ES client UUIDs can be now retrieved from ElasticsearchPreparation
- operation-server UUIDs were replaced by operation server names (this was done in EATL too)

Fixes #271