### PR TITLE
issue-307 : added 'from' and 'size' to ES query

### DIFF
--- a/server/service/individualServices/LinkServices.js
+++ b/server/service/individualServices/LinkServices.js
@@ -473,11 +473,13 @@ exports.getLinkListAsync = async function() {
         index: indexAlias,
         filter_path: "took, hits.hits",
         body: {
+            "from": 0,
+            "size": 9999,
             "query": {
                 "match_all": {}
             }
         }
-    })
+    });
     let linkList = createResultArray(res);
     return { "links" : linkList, "took" : res.body.took };
 }


### PR DESCRIPTION
- this fixes returning only 10 results from methods
 - /v1/list-link-uuids
 - /v1/list-links-to-operation-clients-of-application

Relates to #307 