### PR TITLE
resolve /v1/delete-ltp-and-dependents  throws internal server error for Operation-clinet update if the connected operation-client does not participate in a link

### DIFF
--- a/server/service/individualServices/LinkServices.js
+++ b/server/service/individualServices/LinkServices.js
@@ -313,7 +313,7 @@ exports.deleteDependentLinkPortsAsync = async function (ltpUuid) {
             }
         }
     });
-    if (res.body.hits.length === 0) {
+    if (res.body.hits == undefined || res.body.hits.length === 0) {
         return { "took" : res.body.took };
     }
     let took = res.body.took;


### PR DESCRIPTION
Fixes #404